### PR TITLE
Очистка даты окончания блокировки при установки блокировки сеансов

### DIFF
--- a/src/Классы/КомандаУправлениеСеансами.os
+++ b/src/Классы/КомандаУправлениеСеансами.os
@@ -300,7 +300,7 @@
 
 	КонецЕсли;
 	
-	КомандаВыполнения = СтрокаЗапускаКлиента() + СтрШаблон("infobase update --infobase=""%3""%4 --cluster=""%1""%2 --sessions-deny=%5 --denied-message=""%6"" --denied-from=""%8"" --permission-code=""%7""",
+	КомандаВыполнения = СтрокаЗапускаКлиента() + СтрШаблон("infobase update --infobase=""%3""%4 --cluster=""%1""%2 --sessions-deny=%5 --denied-message=""%6"" --denied-from=""%8"" --denied-to= --permission-code=""%7""",
 		ИдентификаторКластера,
 		КлючиАвторизацииВКластере(),
 		ИдентификаторБазы,


### PR DESCRIPTION
При установке блокировки  пользовательских сеансов если в свойствах базы была задана дата окончания блокировки  и она меньше даты начала блокировки, сеансы заблокированны не будут.
Добавил очистку даты окончания блокировки при блокировке сеансов.