### PR TITLE
ci: корректный прогон тестов на PR из форков

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,95 @@
+# Модель запуска CI
+
+Единая для всех тестовых workflow: `unit-test.yml`, `qa.yml`, `e2e.yml`, `e2e-client.yml`, `e2e-edt.yml`.
+
+## Триггеры
+
+| Событие | Когда | Зачем |
+|---|---|---|
+| `push` в `develop` / `master` / `release/**` | после мержа | пост-мердж прогон целевых веток |
+| `pull_request_target` | открытие/обновление PR | валидация изменений PR |
+| `workflow_dispatch` | вручную | перепрогон по требованию |
+
+Ветки самого репозитория по `push` **не** прогоняются: разработка ведётся через PR, и триггер
+`push` на все ветки давал двойной прогон (ветка + её PR).
+
+## Почему `pull_request_target`, а не `pull_request`
+
+Тестам нужны секреты — учётка портала 1С (`ONEC_USERNAME` / `ONEC_PASSWORD`) для установки
+платформы и лицензии (`ONEC_LICENCE`, `ONEC_SERVER_LICENCE`). PR из форка при событии
+`pull_request` секретов **не получает**, поэтому все джобы с установкой 1С в нём падают в
+принципе — а `unit-test.yml`, где секретов не надо, до недавнего времени вообще висел в
+`action_required`.
+
+`pull_request_target` выполняется в контексте базовой ветки и секреты видит. Плата за это —
+код PR туда не попадает автоматически: по умолчанию checkout берёт базовую ветку, из-за чего
+раньше «E2E (сервер)» показывал зелёный, фактически прогоняя `develop`, а не PR.
+
+Поэтому во всех тестовых workflow код PR забирается явно:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+    allow-unsafe-pr-checkout: true
+```
+
+* `refs/pull/<N>/merge` — merge-коммит PR, то есть ровно то состояние, которое попадёт в
+  базовую ветку. Именно его и надо тестировать.
+* `allow-unsafe-pr-checkout: true` — обязательный опт-ин `actions/checkout` (появился в
+  v4.4.0 / v7). Без него checkout отказывается брать код форка под `pull_request_target`.
+
+## Гейт для форков
+
+`pull_request_target` **не подпадает** под встроенную настройку «Require approval for
+first-time contributors» — она относится только к `pull_request`. То есть без
+дополнительных мер любой PR из форка выполнил бы произвольный код со всеми секретами
+репозитория сразу, без подтверждения.
+
+Поэтому в каждом тестовом workflow есть джоба-допуск:
+
+```yaml
+jobs:
+  gate:
+    name: Допуск прогона кода из форка
+    if: github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-22.04
+    environment: pr-from-fork
+    steps:
+      - run: echo "Мейнтейнер подтвердил прогон кода из форка"
+```
+
+Тестовые джобы висят на `needs: gate` с условием «gate прошёл **или** пропущен»:
+
+```yaml
+    needs: gate
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
+```
+
+* PR из форка → `gate` уходит в ожидание ревью environment'а, мейнтейнер смотрит диф и жмёт
+  **Review deployments → Approve** в шапке прогона. Подтверждение нужно на каждый прогон,
+  то есть после каждого пуша в ветку PR.
+* `push`, `workflow_dispatch`, PR из веток самого репозитория → `gate` пропускается,
+  тесты идут сразу.
+
+### Настройка environment (делается один раз)
+
+`Settings → Environments → New environment` с именем **`pr-from-fork`**, в нём включить
+**Required reviewers** и добавить мейнтейнеров. Секреты в сам environment класть не нужно:
+джобы берут репозиторные, а environment здесь работает только как gate.
+
+Пока environment не создан, `gate` для PR из форка упадёт (`Unable to find environment`),
+и тестовые джобы не запустятся — то есть отказ безопасный.
+
+### Что стоит сделать дополнительно
+
+`OSHUB_TOKEN` (публикация пакета в hub.oscript.io) и `TRIGGER_DOCS_DEPLOY_TOKEN` тестам не
+нужны, но как репозиторные секреты они видны любой джобе, выполняющей код из PR. Их стоит
+перенести в отдельный environment (например `release`) и указать его в `release.yml` /
+`docs-deploy.yaml` — тогда прогон PR до них не дотянется даже при компрометации.
+
+## Правки этих файлов внутри PR не действуют
+
+`pull_request_target` всегда берёт версию workflow из **базовой** ветки. Любые изменения
+в `.github/workflows/**`, приехавшие в PR, вступят в силу только после мержа в `develop`.
+Проверять их удобно через `workflow_dispatch` на ветке.

--- a/.github/workflows/e2e-client.yml
+++ b/.github/workflows/e2e-client.yml
@@ -3,23 +3,45 @@ name: E2E тесты (клиент)
 # Файловые/клиентские E2E-сценарии (tests/e2e/client-tests).
 # Не требуют серверной инфраструктуры - только клиентскую платформу 1С.
 # Прогоняются на матрице ОС × версий платформы × версий OneScript.
+#
+# Модель запуска (триггеры, забор кода PR, гейт для форков) описана в
+# .github/workflows/README.md - она общая для всех тестовых workflow.
 
 on:
   push:
-  pull_request:
+    branches:
+      - develop
+      - master
+      - 'release/**'
   pull_request_target:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
+  contents: read
   checks: write
   pull-requests: write
 
 jobs:
+  # PR из форка выполняет чужой код в доверенном контексте (pull_request_target = секреты
+  # базового репозитория), а встроенный гейт GitHub на pull_request_target не действует.
+  # Поэтому прогон подтверждает мейнтейнер через environment pr-from-fork.
+  # Для push и PR из веток самого репозитория джоба пропускается.
+  gate:
+    name: Допуск прогона кода из форка
+    if: github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-22.04
+    environment: pr-from-fork
+    steps:
+      - name: Подтверждение получено
+        run: echo "Мейнтейнер подтвердил прогон кода из форка"
+
   client-test:
+    needs: gate
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     name: E2E (клиент)
     runs-on: ${{ matrix.os }}
     strategy:
@@ -49,8 +71,13 @@ jobs:
       - name: Актуализация
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          # pull_request_target выполняется в контексте базовой ветки, поэтому код PR
+          # забираем явно - merge-ref'ом, то есть тем, что реально попадёт в базовую ветку.
+          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+          # Осознанный опт-ин на выполнение кода форка в доверенном контексте.
+          # Прикрыт гейтом pr-from-fork выше. Вход появился в actions/checkout 4.4.0,
+          # на которую сейчас указывает тег v4.
+          allow-unsafe-pr-checkout: true
 
       - name: Установка свойств git
         shell: bash

--- a/.github/workflows/e2e-edt.yml
+++ b/.github/workflows/e2e-edt.yml
@@ -11,6 +11,9 @@ name: E2E тесты (EDT)
 #
 # Запускается вручную (workflow_dispatch) и по push/PR, затрагивающим EDT-код, тесты,
 # фикстуры или сам workflow (полная установка EDT+платформы тяжёлая, поэтому не на каждый push).
+#
+# Модель запуска (триггеры, забор кода PR, гейт для форков) описана в
+# .github/workflows/README.md - она общая для всех тестовых workflow.
 
 on:
   workflow_dispatch:
@@ -24,6 +27,10 @@ on:
         required: false
         default: '2025.2.6'
   push:
+    branches:
+      - develop
+      - master
+      - 'release/**'
     paths:
       - '.github/workflows/e2e-edt.yml'
       - 'tests/e2e/edt-tests/**'
@@ -38,7 +45,7 @@ on:
       - 'src/cli/Cfe_Подкоманды/ПодкомандаCfeConvert.os'
       - 'src/cli/Cfe_Подкоманды/ПодкомандаCfeDecompile.os'
       - 'src/cli/НаборыОпций/НаборОпцийИсходников.os'
-  pull_request:
+  pull_request_target:
     paths:
       - '.github/workflows/e2e-edt.yml'
       - 'tests/e2e/edt-tests/**'
@@ -55,15 +62,31 @@ on:
       - 'src/cli/НаборыОпций/НаборОпцийИсходников.os'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
+  contents: read
   checks: write
   pull-requests: write
 
 jobs:
+  # PR из форка выполняет чужой код в доверенном контексте (pull_request_target = секреты
+  # базового репозитория), а встроенный гейт GitHub на pull_request_target не действует.
+  # Поэтому прогон подтверждает мейнтейнер через environment pr-from-fork.
+  # Для push и PR из веток самого репозитория джоба пропускается.
+  gate:
+    name: Допуск прогона кода из форка
+    if: github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-22.04
+    environment: pr-from-fork
+    steps:
+      - name: Подтверждение получено
+        run: echo "Мейнтейнер подтвердил прогон кода из форка"
+
   edt-test:
+    needs: gate
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     name: E2E (EDT)
     runs-on: windows-latest
     env:
@@ -79,6 +102,14 @@ jobs:
 
       - name: Актуализация
         uses: actions/checkout@v4
+        with:
+          # pull_request_target выполняется в контексте базовой ветки, поэтому код PR
+          # забираем явно - merge-ref'ом, то есть тем, что реально попадёт в базовую ветку.
+          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+          # Осознанный опт-ин на выполнение кода форка в доверенном контексте.
+          # Прикрыт гейтом pr-from-fork выше. Вход появился в actions/checkout 4.4.0,
+          # на которую сейчас указывает тег v4.
+          allow-unsafe-pr-checkout: true
 
       - name: Установка свойств git
         shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,22 +7,47 @@ name: E2E тесты (кластер 1С)
 #
 # Файловые/клиентские E2E-сценарии выведены в отдельный workflow e2e-client.yml,
 # где важна матрица ОС и версий платформы.
+#
+# Модель запуска (триггеры, забор кода PR, гейт для форков) описана в
+# .github/workflows/README.md - она общая для всех тестовых workflow.
 
 on:
-  workflow_dispatch:
   push:
-  pull_request:
+    branches:
+      - develop
+      - master
+      - 'release/**'
   pull_request_target:
+  workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  # Ключ - номер PR, а не github.ref_name: под pull_request_target ref_name равен базовой
+  # ветке, из-за чего все PR попадали в одну группу и отменяли прогоны друг друга.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
+  contents: read
   checks: write
+  pull-requests: write
 
 jobs:
+  # PR из форка выполняет чужой код в доверенном контексте (pull_request_target = секреты
+  # базового репозитория), а встроенный гейт GitHub на pull_request_target не действует.
+  # Поэтому прогон подтверждает мейнтейнер через environment pr-from-fork.
+  # Для push и PR из веток самого репозитория джоба пропускается.
+  gate:
+    name: Допуск прогона кода из форка
+    if: github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-22.04
+    environment: pr-from-fork
+    steps:
+      - name: Подтверждение получено
+        run: echo "Мейнтейнер подтвердил прогон кода из форка"
+
   cluster-test:
+    needs: gate
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     name: E2E (сервер)
     runs-on: ubuntu-22.04
     strategy:
@@ -46,6 +71,15 @@ jobs:
     steps:
       - name: Актуализация
         uses: actions/checkout@v4
+        with:
+          # pull_request_target выполняется в контексте базовой ветки, поэтому код PR
+          # забираем явно - merge-ref'ом, то есть тем, что реально попадёт в базовую ветку.
+          # Без этого джоба прогоняла базовую ветку и давала ложно-зелёный результат на PR.
+          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+          # Осознанный опт-ин на выполнение кода форка в доверенном контексте.
+          # Прикрыт гейтом pr-from-fork выше. Вход появился в actions/checkout 4.4.0,
+          # на которую сейчас указывает тег v4.
+          allow-unsafe-pr-checkout: true
 
       - name: Запуск PostgreSQL (whitemanprk/postgres-1c:16)
         # Образ использует стандартный postgres entrypoint. Кастомизация pg_hba.conf

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,34 +1,62 @@
 name: Контроль качества
 
+# Модель запуска (триггеры, забор кода PR, гейт для форков) описана в
+# .github/workflows/README.md - она общая для всех тестовых workflow.
+
 on:
   push:
-  pull_request:
+    branches:
+      - develop
+      - master
+      - 'release/**'
   pull_request_target:
   workflow_dispatch:
-  
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
+  contents: read
   checks: write
   pull-requests: write
 
 jobs:
+  # PR из форка выполняет чужой код в доверенном контексте (pull_request_target = секреты
+  # базового репозитория), а встроенный гейт GitHub на pull_request_target не действует.
+  # Поэтому прогон подтверждает мейнтейнер через environment pr-from-fork.
+  # Для push и PR из веток самого репозитория джоба пропускается.
+  gate:
+    name: Допуск прогона кода из форка
+    if: github.repository == 'vanessa-opensource/vanessa-runner' && github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-22.04
+    environment: pr-from-fork
+    steps:
+      - name: Подтверждение получено
+        run: echo "Мейнтейнер подтвердил прогон кода из форка"
+
   sonar:
-    if: (github.repository == 'vanessa-opensource/vanessa-runner')
+    needs: gate
+    if: ${{ !cancelled()
+      && github.repository == 'vanessa-opensource/vanessa-runner'
+      && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     name: Coverage юнит-тестов + SonarQube
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         oscript_version: ['stable']
-    steps:          
+    steps:
       - name: Актуализация
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          # pull_request_target выполняется в контексте базовой ветки, поэтому код PR
+          # забираем явно - merge-ref'ом, то есть тем, что реально попадёт в базовую ветку.
+          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+          # Осознанный опт-ин на выполнение кода форка в доверенном контексте.
+          # Прикрыт гейтом pr-from-fork выше. Вход появился в actions/checkout 4.4.0,
+          # на которую сейчас указывает тег v4.
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
 
       - name: Вычисление имени ветки
@@ -51,7 +79,7 @@ jobs:
       - name: Установка OneScript
         uses: otymko/setup-onescript@v1.4
         with:
-          version: ${{ steps.extract_oscript_version.outputs.version }} 
+          version: ${{ steps.extract_oscript_version.outputs.version }}
 
       - name: Установка зависимостей пакета
         run: |
@@ -65,7 +93,7 @@ jobs:
 
       - name: Запуск юнит-тестов с покрытием
         run: oscript ./tasks/coverage.os
-        
+
       - name: Извлечение версии пакета
         shell: bash
         run: echo "version=`cat packagedef | grep ".Версия(" | sed 's|[^"]*"||' | sed -r 's/".+//'`" >> $GITHUB_OUTPUT
@@ -75,26 +103,36 @@ jobs:
         uses: warchant/setup-sonar-scanner@v10
 
       - name: Анализ в SonarQube (branch)
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' 
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
           SONARQUBE_HOST: ${{ secrets.SONARQUBE_HOST }}
-        run: sonar-scanner
-          -Dsonar.host.url=${{ env.SONARQUBE_HOST }}
-          -Dsonar.branch.name=${{ env.BRANCH_NAME }}
-          -Dsonar.projectVersion=${{ steps.extract_version.outputs.version }}
+          PROJECT_VERSION: ${{ steps.extract_version.outputs.version }}
+        run: |
+          sonar-scanner \
+            -Dsonar.host.url="$SONARQUBE_HOST" \
+            -Dsonar.branch.name="$BRANCH_NAME" \
+            -Dsonar.projectVersion="$PROJECT_VERSION"
 
       # https://docs.sonarqube.org/latest/analysis/pull-request/
+      # Имя ветки PR задаёт автор PR, а допустимые символы git-ref включают `$`, обратные
+      # кавычки и `;`. Поэтому все значения из контекста PR передаются через env, а не
+      # подставляются в текст скрипта.
       - name: Анализ в SonarQube (pull-request)
-        if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
           SONARQUBE_HOST: ${{ secrets.SONARQUBE_HOST }}
-        run: sonar-scanner
-          -Dsonar.host.url=${{ env.SONARQUBE_HOST }}
-          -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
-          -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}
-          -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}
-          -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
+          PR_KEY: ${{ github.event.pull_request.number }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          sonar-scanner \
+            -Dsonar.host.url="$SONARQUBE_HOST" \
+            -Dsonar.pullrequest.key="$PR_KEY" \
+            -Dsonar.pullrequest.branch="$PR_BRANCH" \
+            -Dsonar.pullrequest.base="$PR_BASE" \
+            -Dsonar.scm.revision="$PR_SHA"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,20 +1,43 @@
 name: Юнит-тесты
 
+# Модель запуска (триггеры, забор кода PR, гейт для форков) описана в
+# .github/workflows/README.md - она общая для всех тестовых workflow.
+
 on:
   push:
-  pull_request:
+    branches:
+      - develop
+      - master
+      - 'release/**'
+  pull_request_target:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
+  contents: read
   checks: write
   pull-requests: write
 
 jobs:
+  # PR из форка выполняет чужой код в доверенном контексте (pull_request_target = секреты
+  # базового репозитория), а встроенный гейт GitHub на pull_request_target не действует.
+  # Поэтому прогон подтверждает мейнтейнер через environment pr-from-fork.
+  # Для push и PR из веток самого репозитория джоба пропускается.
+  gate:
+    name: Допуск прогона кода из форка
+    if: github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-22.04
+    environment: pr-from-fork
+    steps:
+      - name: Подтверждение получено
+        run: echo "Мейнтейнер подтвердил прогон кода из форка"
+
   unit-test:
+    needs: gate
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -25,8 +48,13 @@ jobs:
       - name: Актуализация
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          # pull_request_target выполняется в контексте базовой ветки, поэтому код PR
+          # забираем явно - merge-ref'ом, то есть тем, что реально попадёт в базовую ветку.
+          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+          # Осознанный опт-ин на выполнение кода форка в доверенном контексте.
+          # Прикрыт гейтом pr-from-fork выше. Вход появился в actions/checkout 4.4.0,
+          # на которую сейчас указывает тег v4.
+          allow-unsafe-pr-checkout: true
 
       - name: Установка свойств git
         shell: bash


### PR DESCRIPTION
Тесты на PR из форка не запускались вовсе (см. #733):

* `unit-test` висел в `action_required` — только триггер `pull_request`;
* `qa` и `e2e-client` падали на checkout: `actions/checkout@v4` уехал на 4.4.0, где появился гард `Refusing to check out fork pull request code`;
* `e2e` прогонял базовую ветку вместо PR и давал ложно-зелёный чек.

## Единая модель для всех тестовых workflow

* Триггеры — `push` в `develop`/`master`/`release/**`, `pull_request_target`, `workflow_dispatch`. `pull_request` убран: форку при нём не отдаются секреты (учётка портала 1С и лицензии), без которых тесты не поднимаются в принципе.
* Код PR забирается явно: `ref: refs/pull/N/merge` + `allow-unsafe-pr-checkout: true`.
* Прогон кода из форка гейтится джобой `gate` с `environment: pr-from-fork` (обязательный ревьюер: Segate-ekb / artbear / otymko). Встроенная настройка «Require approval for first-time contributors» на `pull_request_target` **не действует**, поэтому без гейта секреты репозитория были бы доступны любому автору PR без подтверждения.

PR из веток самого репозитория и `push` идут без подтверждения — `gate` пропускается.

## Попутные фиксы

* `concurrency` в `e2e.yml` — по номеру PR, а не по `github.ref_name`: под `pull_request_target` `ref_name` равен базовой ветке, из-за чего все PR попадали в одну группу и отменяли прогоны друг друга.
* Имя ветки PR в шаге sonar передаётся через `env`, а не подставляется в текст скрипта (в git-ref разрешены обратные кавычки, `$` и `;` → инъекция команд).
* Явный `permissions.contents: read`.

Модель целиком описана в `.github/workflows/README.md`.

> [!NOTE]
> `pull_request_target` всегда берёт workflow из базовой ветки, поэтому на открытых PR новая схема заработает только после мержа. Чеки на этом PR — по старой конфигурации.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
