### PR TITLE
ci: развести concurrency-группы pull_request и pull_request_target

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -88,6 +88,23 @@ jobs:
 перенести в отдельный environment (например `release`) и указать его в `release.yml` /
 `docs-deploy.yaml` — тогда прогон PR до них не дотянется даже при компрометации.
 
+## Concurrency
+
+Ключ группы включает `github.event_name`:
+
+```yaml
+group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+```
+
+Событие в ключе нужно из-за переходного периода. Прогон по `pull_request` читает workflow
+**из ветки PR**, а не из базовой, поэтому у PR, открытых до перехода на
+`pull_request_target`, старая версия файла с триггером `pull_request` продолжает
+запускаться. Без `event_name` в ключе такой прогон попадает в ту же группу и отменяет наш
+прогон по `pull_request_target`. Дубли уйдут сами, как только ветки PR подтянут `develop`.
+
+Номер PR в ключе — вместо `github.ref_name`: под `pull_request_target` `ref_name` равен
+базовой ветке, и все PR оказывались в одной группе, отменяя прогоны друг друга.
+
 ## Правки этих файлов внутри PR не действуют
 
 `pull_request_target` всегда берёт версию workflow из **базовой** ветки. Любые изменения

--- a/.github/workflows/e2e-client.yml
+++ b/.github/workflows/e2e-client.yml
@@ -17,7 +17,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # event входит в ключ намеренно: у PR, открытых до перехода на pull_request_target,
+  # в ветке лежит старая версия этого workflow с триггером pull_request, а её прогон
+  # читается из ветки PR. Без event в группе он попадал бы в ту же группу и отменял
+  # наш прогон по pull_request_target.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/e2e-edt.yml
+++ b/.github/workflows/e2e-edt.yml
@@ -62,7 +62,11 @@ on:
       - 'src/cli/НаборыОпций/НаборОпцийИсходников.os'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # event входит в ключ намеренно: у PR, открытых до перехода на pull_request_target,
+  # в ветке лежит старая версия этого workflow с триггером pull_request, а её прогон
+  # читается из ветки PR. Без event в группе он попадал бы в ту же группу и отменял
+  # наш прогон по pull_request_target.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,12 @@ on:
 concurrency:
   # Ключ - номер PR, а не github.ref_name: под pull_request_target ref_name равен базовой
   # ветке, из-за чего все PR попадали в одну группу и отменяли прогоны друг друга.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  #
+  # event входит в ключ намеренно: у PR, открытых до перехода на pull_request_target,
+  # в ветке лежит старая версия этого workflow с триггером pull_request, а её прогон
+  # читается из ветки PR. Без event в группе он попадал бы в ту же группу и отменял
+  # наш прогон по pull_request_target.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -13,7 +13,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # event входит в ключ намеренно: у PR, открытых до перехода на pull_request_target,
+  # в ветке лежит старая версия этого workflow с триггером pull_request, а её прогон
+  # читается из ветки PR. Без event в группе он попадал бы в ту же группу и отменял
+  # наш прогон по pull_request_target.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,7 +13,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # event входит в ключ намеренно: у PR, открытых до перехода на pull_request_target,
+  # в ветке лежит старая версия этого workflow с триггером pull_request, а её прогон
+  # читается из ветки PR. Без event в группе он попадал бы в ту же группу и отменял
+  # наш прогон по pull_request_target.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Follow-up к #734, найдено на живом прогоне #733: из пяти прогонов `pull_request_target` выжил только один, остальные четыре — `cancelled` через ~23 секунды.

Причина: прогон по `pull_request` читает workflow **из ветки PR**, а не из базовой. У PR, открытых до перехода на `pull_request_target`, в ветке лежит старая версия файла с триггером `pull_request` — и она продолжает запускаться. Ключ группы concurrency совпадал (`workflow` + номер PR), поэтому старый прогон отменял новый.

Добавляем `github.event_name` в ключ группы. Дубли уйдут сами, как только ветки открытых PR подтянут `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
